### PR TITLE
fix: remove secret scanner alert, OLLAMA_HOST in embedding.py, exp08 JudgeClient mock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,11 @@
 
 # ---------------------------------------------------------------------------
 # Required: MongoDB connection URI
-# If using the bundled docker-compose.yaml, use:
-#   MONGO_URI=mongodb://admin:changeme@localhost:27017/
-# For an external Atlas cluster:
-#   MONGO_URI=mongodb+srv://user:pass@cluster.mongodb.net/
+# If using the bundled docker-compose.yaml, set this to:
+#   mongodb://<MONGO_USERNAME>:<MONGO_PASSWORD>@localhost:27017/
+# where MONGO_USERNAME and MONGO_PASSWORD match the values below.
+# For an external Atlas cluster, set this to your Atlas connection string
+# (found in the Atlas UI under "Connect > Drivers").
 # ---------------------------------------------------------------------------
 MONGO_URI=mongodb://localhost:27017/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# --- Git worktrees ---
+.worktrees/
+
 # --- Environment variables ---
 .env
 .env.local

--- a/backend/app/core/embedding.py
+++ b/backend/app/core/embedding.py
@@ -1,10 +1,12 @@
+import os
 from typing import List
 from .database_handlers import OllamaEmbeddingFunction
 
 class EmbeddingCreator:
     def __init__(self):
+        ollama_host = os.environ.get("OLLAMA_HOST", "http://localhost:11435")
         self.ef = OllamaEmbeddingFunction(
-            url="http://localhost:11435/api/embeddings",
+            url=f"{ollama_host}/api/embeddings",
             model_name="nomic-embed-text"
         )
     

--- a/experiments/08_rag_real_world/run_experiment.py
+++ b/experiments/08_rag_real_world/run_experiment.py
@@ -77,20 +77,25 @@ class JudgeClient:
             keys = os.environ.get("OPENAI_API_KEY", "").split(",")
             self.api_keys = [k.strip() for k in keys if k.strip()]
             if not self.api_keys:
-                print("WARN: OPENAI_API_KEY not set. Using mock judge.")
-                self.client = None 
-            else:
-                from openai import OpenAI
-                self.client = OpenAI(api_key=self.api_keys[0])
+                raise ValueError(
+                    "OPENAI_API_KEY environment variable is not set or is empty. "
+                    "Run: export OPENAI_API_KEY=your_key_here\n"
+                    "Without a valid key, judge scores would be fabricated. Aborting."
+                )
+            from openai import OpenAI
+            self.client = OpenAI(api_key=self.api_keys[0])
             
         elif judge_type == "groq":
             keys = os.environ.get("GROQ_API_KEY", "").split(",")
             self.api_keys = [k.strip() for k in keys if k.strip()]
             if not self.api_keys:
-                 self.client = None
-            else:
-                from groq import Groq
-                self.client = Groq(api_key=self.api_keys[0])
+                raise ValueError(
+                    "GROQ_API_KEY environment variable is not set or is empty. "
+                    "Run: export GROQ_API_KEY=your_key_here\n"
+                    "Without a valid key, judge scores would be fabricated. Aborting."
+                )
+            from groq import Groq
+            self.client = Groq(api_key=self.api_keys[0])
 
     def _rotate_key(self):
         """Rotate to next API key if available."""
@@ -114,10 +119,7 @@ class JudgeClient:
         """Score prediction against ground truth."""
         if not prediction or len(prediction.strip()) < 5:
             return 0.0
-            
-        if not self.client: # Mock mode
-            return 0.5
-        
+
         prompt = f"""Compare these two root cause descriptions and rate their similarity from 0.0 to 1.0.
 
 Ground Truth: {ground_truth}
@@ -134,7 +136,10 @@ Respond with ONLY a number between 0.0 and 1.0:"""
                 print(f"  Judge attempt {attempt+1}/3 failed: {e}")
                 time.sleep(2)
         
-        return 0.5
+        # All retries exhausted — return 0.0 and warn rather than silently return 0.5
+        print(f"  WARNING: all scoring attempts failed for judge '{self.judge_name}'. "
+              f"Returning 0.0 (not a mock). Check API key and connectivity.")
+        return 0.0
     
     def _call_judge(self, prompt: str) -> Optional[float]:
         judge_type = self.judge_config["type"]


### PR DESCRIPTION
## Summary

Three follow-up fixes identified during code review of PR #8.

## Changes

### Security: remove credential pattern from `.env.example`
The comment block in `.env.example` contained an inline URI example in the form `mongodb+srv://user:pass@cluster.mongodb.net/` which triggered GitHub's secret scanner alert. No real credentials were present — this was placeholder text. The comment has been rewritten as a plain description pointing users to the Atlas UI, removing the pattern that matched the scanner rule.

### `backend/app/core/embedding.py` — read `OLLAMA_HOST` env var
`EmbeddingCreator` was hardcoding `url="http://localhost:11435/api/embeddings"` directly in the `OllamaEmbeddingFunction` constructor. Every other file in the backend (`database_handlers.py`, `rag.py`, `log_parser.py`) was updated in the previous round to read from `os.environ.get("OLLAMA_HOST", "http://localhost:11435")`. This makes `embedding.py` consistent with the rest of the codebase, so a non-default Ollama host only needs to be set in one place.

### `experiments/08_rag_real_world/run_experiment.py` — fix silent mock scoring in `JudgeClient`
The `JudgeClient` class in experiment 08 was not updated when the identical class in experiment 07 was fixed. Specifically:
- `_init_client()` was silently setting `self.client = None` when `OPENAI_API_KEY` or `GROQ_API_KEY` were absent, instead of raising an error
- `score()` was returning a fixed `0.5` both on the null-client early-exit path and after retry exhaustion

A run with a missing or misconfigured API key would produce output indistinguishable from a real run, with fabricated scores. Both paths now match experiment 07: `_init_client()` raises `ValueError` on missing keys, and `score()` returns `0.0` with an explicit warning after retry exhaustion.

## Related
Closes the remaining items from the review of #8.

cc @chxmq — tagging you for review since these are fixes to code you authored.